### PR TITLE
Allow defining the service and launch type for running fargate tasks

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -31,10 +31,12 @@ It can modify the container command.
 		exitCode, err := lib.RunTask(
 			viper.GetString("profile"),
 			viper.GetString("cluster"),
+			viper.GetString("run.service"),
 			viper.GetString("task_definition"),
 			viper.GetString("image_tag"),
 			containerName,
 			viper.GetString("log_group"),
+			viper.GetString("run.launch_type"),
 			commandArgs,
 		)
 		if err != nil {
@@ -52,4 +54,5 @@ func init() {
 	viper.BindPFlag("log_group", runCmd.PersistentFlags().Lookup("log_group"))
 	viper.BindPFlag("container_name", runCmd.PersistentFlags().Lookup("container_name"))
 	viper.BindPFlag("task_definition", runCmd.PersistentFlags().Lookup("task_definition"))
+	viper.SetDefault("run.launch_type", "EC2")
 }

--- a/example.toml
+++ b/example.toml
@@ -13,3 +13,7 @@ shell = "bash"
 service = "app"
 container_name = "app"
 instance_user = "ec2-user"
+
+[run]
+service = "app" # Name of service to run one off task in
+launch_type = "EC2" # FARGATE if the task_definition requires FARGATE


### PR DESCRIPTION
Fargate tasks require the network configuration to be defined to run. 
This requires fetching it from the service.