### PR TITLE
Fixes event display during "ecs-tool deploy"

### DIFF
--- a/lib/deploy.go
+++ b/lib/deploy.go
@@ -155,7 +155,7 @@ func deployService(ctx log.Interface, cluster, imageTag string, service string, 
 				return last
 			}
 			for _, event := range describeResult.Services[0].Events {
-				if aws.TimeValue(event.CreatedAt).After(last) {
+				if !aws.TimeValue(event.CreatedAt).Before(last) {
 					ctx.Info(aws.StringValue(event.Message))
 					last = aws.TimeValue(event.CreatedAt)
 				}


### PR DESCRIPTION
Previously it would skip some events due to second granularity of the
DescribeServices.Services[x].Events
The solution is pretty simple: change time.After to !time.Before

Fixes #15