### PR TITLE
fix(ssh): bind ssh.task_definition to sshCmd's own flag

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -40,7 +40,11 @@ var sshCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(sshCmd)
 	sshCmd.PersistentFlags().StringP("task_definition", "t", "", "name of task definition to use (required)")
-	viper.BindPFlag("ssh.task_definition", runCmd.PersistentFlags().Lookup("task_definition"))
+	// Bind to sshCmd's own flag. runCmd does not define task_definition
+	// (its BindPFlag call is commented out), so the lookup returned a
+	// nil *pflag.Flag and any later viper.Get("ssh.task_definition")
+	// call panicked inside pflagValue.HasChanged.
+	viper.BindPFlag("ssh.task_definition", sshCmd.PersistentFlags().Lookup("task_definition"))
 
 	viper.SetDefault("ssh.push_ssh_key", true)
 	viper.SetDefault("ssh.task_definition", viper.GetString("task_definition"))


### PR DESCRIPTION
Fixes springload/ecs-tool#41.

## Problem

`cmd/ssh.go` binds `ssh.task_definition` to `runCmd`'s `task_definition` flag:

```go
sshCmd.PersistentFlags().StringP("task_definition", ...)
viper.BindPFlag("ssh.task_definition", runCmd.PersistentFlags().Lookup("task_definition"))
```

But `runCmd` doesn't define `task_definition`, its `BindPFlag` call is commented out in `cmd/run.go:58`. `Lookup` returns a nil `*pflag.Flag`, `viper.BindPFlag` silently stores the nil binding, and the first `viper.Get("ssh.task_definition")` in the command path panics inside `pflagValue.HasChanged`:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/spf13/viper.pflagValue.HasChanged flags.go:41
github.com/spf13/viper.(*Viper).find viper.go:914
github.com/springload/ecs-tool/cmd.glob..func9 ssh.go:26
```

This crashes `ecs-tool ssh` on any invocation (v1.9.8 regression, v1.9.7 works).

## Fix

Bind to `sshCmd`'s own `PersistentFlags`, which is where the flag is actually registered two lines above.

## Test

`go build ./...` and `go vet ./cmd/...` clean. Package has no existing tests; the regression is that running the `ssh` subcommand no longer panics.