### PR TITLE
Propagate task definition tags through RegisterTaskDefinition

### DIFF
--- a/lib/deploy.go
+++ b/lib/deploy.go
@@ -81,6 +81,7 @@ func deployService(ctx log.Interface, cluster, imageTag string, imageTags []stri
 	// then describe the task definition to get a copy of it
 	describeTaskResult, err := svc.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: describeResult.Services[0].TaskDefinition,
+		Include:        aws.StringSlice([]string{"TAGS"}),
 	})
 	if err != nil {
 		ctx.WithError(err).Error("Can't get task definition")
@@ -107,6 +108,7 @@ func deployService(ctx log.Interface, cluster, imageTag string, imageTags []stri
 		RequiresCompatibilities: taskDefinition.Compatibilities,
 		TaskRoleArn:             taskDefinition.TaskRoleArn,
 		Volumes:                 taskDefinition.Volumes,
+		Tags:                    describeTaskResult.Tags,
 	})
 	if err != nil {
 		ctx.WithError(err).Error("Can't register task definition")

--- a/lib/run.go
+++ b/lib/run.go
@@ -23,6 +23,7 @@ func RunTask(profile, cluster, service, taskDefinitionName, imageTag string, ima
 
 	describeResult, err := svc.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: aws.String(taskDefinitionName),
+		Include:        aws.StringSlice([]string{"TAGS"}),
 	})
 	if err != nil {
 		ctx.WithError(err).Error("Can't get task definition")
@@ -67,6 +68,7 @@ func RunTask(profile, cluster, service, taskDefinitionName, imageTag string, ima
 		RequiresCompatibilities: taskDefinition.Compatibilities,
 		TaskRoleArn:             taskDefinition.TaskRoleArn,
 		Volumes:                 taskDefinition.Volumes,
+		Tags:                    describeResult.Tags,
 	})
 	if err != nil {
 		ctx.WithError(err).Error("Can't register task definition")

--- a/lib/runFargate.go
+++ b/lib/runFargate.go
@@ -63,6 +63,7 @@ func RunFargate(profile, cluster, service, taskDefinitionName, imageTag string, 
 
 	describeResult, err := svc.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: aws.String(taskDefinitionName),
+		Include:        aws.StringSlice([]string{"TAGS"}),
 	})
 	if err != nil {
 		ctx.WithError(err).Error("Can't get task definition")
@@ -111,6 +112,7 @@ func RunFargate(profile, cluster, service, taskDefinitionName, imageTag string, 
 		RequiresCompatibilities: taskDefinition.Compatibilities,
 		TaskRoleArn:             taskDefinition.TaskRoleArn,
 		Volumes:                 taskDefinition.Volumes,
+		Tags:                    describeResult.Tags,
 	})
 	if err != nil {
 		ctx.WithError(err).Error("Can't register task definition")


### PR DESCRIPTION
## Summary

- `DescribeTaskDefinition` now requests `TAGS` via `Include`
- `RegisterTaskDefinition` passes those tags through when registering the new revision
- Applied consistently in `lib/run.go`, `lib/deploy.go`, and `lib/runFargate.go`

This keeps the tags on existing task definitions (typically set by Terraform) intact across `ecs-tool` deploys and run-task invocations.

## Motivation

Without this change, every `ecs-tool` deploy / run creates a new task definition revision **without tags**, even when the previous revision (Terraform-managed) was correctly tagged. The tags effectively disappear on the next CI deploy and the service ends up pointing to an untagged revision.

This also unblocks deploys against AWS accounts where an SCP enforces mandatory tag keys on \`ecs:RegisterTaskDefinition\`. Example failure (from a WCC org SCP gating on \`aws:TagKeys\`):

\`\`\`
AccessDeniedException: User: arn:aws:iam::...:user/...-deploy is not authorized
to perform: ecs:RegisterTaskDefinition on resource: ...task-definition/...:*
with an explicit deny in a service control policy: ...
\`\`\`

With this PR, the new revision inherits the tags from the previous one, so \`aws:TagKeys\` is populated in the API request and the SCP passes.

## Backward compatibility

Projects that don't tag their task definitions: \`DescribeTaskDefinition\` returns an empty \`Tags\` slice, and the \`RegisterTaskDefinition\` call passes nil tags as before. Behaviour unchanged.

## Test plan

- [x] \`go build\` succeeds
- [x] \`go test ./...\` — existing tests pass (1 test: \`TestParseTaskUUID\`)
- [x] Manual end-to-end against a real AWS account:
  - Built local binary from this branch
  - Ran \`ecs-tool run\` against a preview ECS cluster whose task definition revision had the required tags
  - New revision was registered successfully and inherited all tags from the previous revision (verified via \`aws ecs describe-task-definition --include TAGS\`)
  - Prior to this patch, the same call returned \`AccessDeniedException\` on \`ecs:RegisterTaskDefinition\` due to the SCP